### PR TITLE
Use nested includes for project sections

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -21,5 +21,6 @@ format:
     toc-depth: 4
     toc-location: right
     extensions: [markdown+raw_html]
+    title-block-style: none
 
 filters: [obs.lua]

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -3,16 +3,16 @@ project:
   type: website
   render:
     - notebook250708.qmd
-    - project1/subproject1/tasks.qmd
+    - project1/index.qmd
 
 website:
   sidebar:
     contents:
       - notebook250708.qmd
-      - project1/subproject1/tasks.qmd
+      - project1/index.qmd
 
 execute:
-  cache: true
+  cache: false
   jupyter: python3
 
 format:

--- a/notebook250708.qmd
+++ b/notebook250708.qmd
@@ -6,5 +6,5 @@ title: "Daily Log: 2025-07-08"
 
 This notebook links to specific tasks in subprojects:
 
-- Task 1: See Section [Task 1](project1/index.html#sec:task1).
-- Task 2: See Section [Task 2](project1/index.html#sec:task2).
+- Task 1: See Section @sec:task1
+- Task 2: See Section @sec:task2

--- a/notebook250708.qmd
+++ b/notebook250708.qmd
@@ -6,5 +6,5 @@ title: "Daily Log: 2025-07-08"
 
 This notebook links to specific tasks in subprojects:
 
-- Task 1: See Section [Task 1](project1/subproject1/tasks.qmd#sec:task1).
-- Task 2: See Section [Task 2](project1/subproject1/tasks.qmd#sec:task2).
+- Task 1: See Section [Task 1](project1/index.html#sec:task1).
+- Task 2: See Section [Task 2](project1/index.html#sec:task2).

--- a/project1/index.qmd
+++ b/project1/index.qmd
@@ -1,7 +1,8 @@
 ---
 title: "Project1"
+format:
+  html:
+    title-block-style: none
 ---
-
-# Project1
 
 {{< include subproject1/index.qmd >}}

--- a/project1/index.qmd
+++ b/project1/index.qmd
@@ -1,0 +1,7 @@
+---
+title: "Project1"
+---
+
+# Project1
+
+{{< include subproject1/index.qmd >}}

--- a/project1/index.qmd
+++ b/project1/index.qmd
@@ -1,8 +1,5 @@
 ---
 title: "Project1"
-format:
-  html:
-    title-block-style: none
 ---
 
 {{< include subproject1/index.qmd >}}

--- a/project1/subproject1/index.qmd
+++ b/project1/subproject1/index.qmd
@@ -1,0 +1,3 @@
+## SubProject1
+
+{{< include subproject1/tasks.qmd >}}

--- a/project1/subproject1/tasks.qmd
+++ b/project1/subproject1/tasks.qmd
@@ -1,11 +1,3 @@
----
-title: "Project1 SubProject1 Tasks"
----
-
-# Project1
-
-## SubProject1
-
 ### Question: Improve Data Processing
 
 #### Task 1 {#sec:task1}

--- a/resolve_refs.py
+++ b/resolve_refs.py
@@ -1,12 +1,56 @@
 #!/usr/bin/env python3
 import re
 from pathlib import Path
+import yaml
+
+include_pattern = re.compile(r"\{\{\s*<\s*include\s+([^>\s]+)\s*>\s*\}\}")
 
 # Collect anchor definitions {#sec:id}, {#fig:id}, {#tab:id}
 anchor_pattern = re.compile(r"\{#(sec|fig|tab):([A-Za-z0-9_-]+)\}")
 heading_pattern = re.compile(r"^(#+)\s+(.*?)\s*\{#(sec|fig|tab):([A-Za-z0-9_-]+)\}")
 
-def collect_anchors():
+def load_rendered_files():
+    cfg = yaml.safe_load(Path('_quarto.yml').read_text())
+    return set(cfg.get('project', {}).get('render', []))
+
+
+def build_include_map(render_files):
+    included_by = {}
+    for root_file in render_files:
+        root_dir = Path(root_file).parent
+        stack = [Path(root_file).resolve()]
+        visited = set()
+        while stack:
+            current = stack.pop()
+            if current in visited or not current.exists():
+                continue
+            visited.add(current)
+            content = current.read_text()
+            for inc in include_pattern.findall(content):
+                target = (root_dir / inc).resolve()
+                try:
+                    target_rel = target.relative_to(Path('.').resolve())
+                    current_rel = current.relative_to(Path('.').resolve())
+                except ValueError:
+                    target_rel = target
+                    current_rel = current
+                target_path = target_rel.as_posix()
+                included_by.setdefault(target_path, []).append(current_rel.as_posix())
+                stack.append(target)
+    return included_by
+
+
+def resolve_render_file(file, included_by, render_files):
+    visited = set()
+    while file not in render_files:
+        if file in visited or file not in included_by:
+            break
+        visited.add(file)
+        file = included_by[file][0]
+    return file
+
+
+def collect_anchors(render_files, included_by):
     anchors = {}
     for path in Path('.').rglob('*.qmd'):
         lines = path.read_text().splitlines()
@@ -18,7 +62,8 @@ def collect_anchors():
                 hm = heading_pattern.match(line)
                 if hm:
                     text = hm.group(2).strip()
-                anchors[key] = (str(path), text)
+                render_file = resolve_render_file(path.as_posix(), included_by, render_files)
+                anchors[key] = (render_file, text)
     return anchors
 
 ref_pattern = re.compile(r"@(sec|fig|tab):([A-Za-z0-9_-]+)")
@@ -32,7 +77,8 @@ def replace_refs(path, anchors):
         if key in anchors:
             changed = True
             file, text = anchors[key]
-            return f"[{text}]({file}#{key})"
+            link = f"{file.replace('.qmd', '.html')}#{key}"
+            return f"[{text}]({link})"
         return match.group(0)
     content = path.read_text()
     new_content = ref_pattern.sub(repl, content)
@@ -41,6 +87,8 @@ def replace_refs(path, anchors):
     return changed
 
 if __name__ == "__main__":
-    anchors = collect_anchors()
+    render_files = load_rendered_files()
+    include_map = build_include_map(render_files)
+    anchors = collect_anchors(render_files, include_map)
     for path in Path('.').rglob('*.qmd'):
         replace_refs(path, anchors)


### PR DESCRIPTION
## Summary
- add index files at project and subproject levels
- include tasks via shortcodes
- render only the project index in `_quarto.yml`
- disable execution caching to avoid jupyter-cache dependency
- remove redundant headers from tasks

## Testing
- `quarto render`

------
https://chatgpt.com/codex/tasks/task_e_686d96c0408c832b866c08fe0ccc5b88