### PR TITLE
Refactor LaTeX converter as Python script

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -4,15 +4,17 @@ project:
   render:
     - notebook250708.qmd
     - project1/index.qmd
+    - project1/example.qmd
 
 website:
   sidebar:
     contents:
       - notebook250708.qmd
       - project1/index.qmd
+      - project1/example.qmd
 
 execute:
-  cache: false
+  cache: true
   jupyter: python3
 
 format:

--- a/obs.lua
+++ b/obs.lua
@@ -88,7 +88,7 @@ function Para(para)
         pandoc.Span({pandoc.Str('DEBUG:')}, pandoc.Attr('', {}, {style = 'color:grey;'}))
       })
       local body = pandoc.Para(inner)
-      local div = pandoc.Div({header, body}, pandoc.Attr('', {}, {style = 'margin:10px; border:1px solid grey;'}))
+      local div = pandoc.Div({header, pandoc.Div({body}, pandoc.Attr('', {}, {style = 'margin:10px; border:0px;'}))}, pandoc.Attr('', {}, {style = 'margin:0px; border:1px solid grey; padding:0px;'}))
       out_blocks:insert(div)
     else
       buf:insert(el)

--- a/project1/example.qmd
+++ b/project1/example.qmd
@@ -1,0 +1,22 @@
+# Example project
+
+This is an example project!! I'm learning to plot in python!
+
+## some basic examples!
+
+### example plot {#sec:examplePlot1}
+
+Here's an example plot! <obs time="7/8/25 20:08" author="JF">this
+is what I observe about the plot</obs> <err> <obs
+time="7/8/25 20:06" author="JF">I had some problems making the
+plot</obs> then I do some stuff to fix the problems <obs
+time="7/8/25 20:08" author="JF">here are notes about the specific
+solution</obs> </err>
+
+```{python}
+from pylab import *
+from pyspecdata import *
+with figlist_var() as fl:
+    fl.next('this is a plot')
+    fl.plot(r_[0:10])
+```

--- a/project1/example.qmd
+++ b/project1/example.qmd
@@ -7,14 +7,11 @@ This is an example project!! I'm learning to plot in python!
 ### example plot {#sec:examplePlot1}
 
 Here's an example plot!
-<obs time="7/8/25 20:08" author="JF"> this is what I observe about the
-                                     plot</obs>
+<obs time="7/8/25 20:08" author="JF">this is what I observe about the plot</obs>
 <err>
-    <obs time="7/8/25 20:06" author="JF"> I had some problems making the plot</obs>
-    then
-    I do some stuff to fix the problems
-    <obs time="7/8/25 20:08" author="JF"> here are notes about the specific
-                                         solution</obs>
+    <obs time="7/8/25 20:06" author="JF">I had some problems making the plot</obs>
+    then I do some stuff to fix the problems
+    <obs time="7/8/25 20:08" author="JF">here are notes about the specific solution</obs>
 </err>
 
 ```{python}

--- a/project1/example.qmd
+++ b/project1/example.qmd
@@ -15,9 +15,15 @@ Here's an example plot!
 </err>
 
 ```{python}
-from pylab import *
-from pyspecdata import *
-with figlist_var() as fl:
-    fl.next('this is a plot')
-    fl.plot(r_[0:10])
+%load_ext pyspecdata.ipy
+from pyspecdata import nddata
+from numpy import r_
+x = nddata(r_[0:10],'x')
+x
+```
+
+now show the square
+
+```{python}
+x**2
 ```

--- a/project1/example.qmd
+++ b/project1/example.qmd
@@ -7,11 +7,11 @@ This is an example project!! I'm learning to plot in python!
 ### example plot {#sec:examplePlot1}
 
 Here's an example plot! <obs time="7/8/25 20:08" author="JF">this
-is what I observe about the plot</obs> <err> <obs
-time="7/8/25 20:06" author="JF">I had some problems making the
-plot</obs> then I do some stuff to fix the problems <obs
-time="7/8/25 20:08" author="JF">here are notes about the specific
-solution</obs> </err>
+is what I observe about the plot</obs> <err> <obs time="7/8/25
+20:06" author="JF">I had some problems making the plot</obs> then
+I do some stuff to fix the problems <obs time="7/8/25 20:08"
+author="JF">here are notes about the specific solution</obs>
+</err>
 
 ```{python}
 from pylab import *

--- a/project1/example.qmd
+++ b/project1/example.qmd
@@ -6,12 +6,19 @@ This is an example project!! I'm learning to plot in python!
 
 ### example plot {#sec:examplePlot1}
 
-Here's an example plot! <obs time="7/8/25 20:08" author="JF">this
-is what I observe about the plot</obs> <err> <obs time="7/8/25
-20:06" author="JF">I had some problems making the plot</obs> then
-I do some stuff to fix the problems <obs time="7/8/25 20:08"
-author="JF">here are notes about the specific solution</obs>
+Here's an example plot!
+<obs time="7/8/25 20:08" author="JF">
+this
+is what I observe about the plot</obs>
+<err>
+
+    <obs time="7/8/25 20:06" author="JF">
+    I had some problems making the plot</obs>     then
+    I do some stuff to fix the problems
+    <obs time="7/8/25 20:08" author="JF">
+    here are notes about the specific solution</obs>
 </err>
+
 
 ```{python}
 from pylab import *

--- a/project1/example.qmd
+++ b/project1/example.qmd
@@ -6,17 +6,13 @@ This is an example project!! I'm learning to plot in python!
 
 ### example plot {#sec:examplePlot1}
 
-Here's an example plot!
-<obs time="7/8/25 20:08" author="JF">
-this
-is what I observe about the plot</obs>
+Here's an example plot! <obs time="7/8/25 20:08" author="JF"> this is what I observe about the
+plot</obs>
 <err>
-
-    <obs time="7/8/25 20:06" author="JF">
-    I had some problems making the plot</obs>     then
-    I do some stuff to fix the problems
-    <obs time="7/8/25 20:08" author="JF">
-    here are notes about the specific solution</obs>
+    <obs time="7/8/25 20:06" author="JF"> I had some problems making the plot</obs>
+    then
+    I do some stuff to fix the problems <obs time="7/8/25 20:08" author="JF"> here are notes about the specific
+    solution</obs>
 </err>
 
 
@@ -24,6 +20,6 @@ is what I observe about the plot</obs>
 from pylab import *
 from pyspecdata import *
 with figlist_var() as fl:
-    fl.next('this is a plot')
-    fl.plot(r_[0:10])
+fl.next('this is a plot')
+fl.plot(r_[0:10])
 ```

--- a/project1/example.qmd
+++ b/project1/example.qmd
@@ -6,15 +6,16 @@ This is an example project!! I'm learning to plot in python!
 
 ### example plot {#sec:examplePlot1}
 
-Here's an example plot! <obs time="7/8/25 20:08" author="JF"> this is what I observe about the
+Here's an example plot!
+<obs time="7/8/25 20:08" author="JF"> this is what I observe about the
 plot</obs>
 <err>
     <obs time="7/8/25 20:06" author="JF"> I had some problems making the plot</obs>
     then
-    I do some stuff to fix the problems <obs time="7/8/25 20:08" author="JF"> here are notes about the specific
+    I do some stuff to fix the problems
+    <obs time="7/8/25 20:08" author="JF"> here are notes about the specific
     solution</obs>
 </err>
-
 
 ```{python}
 from pylab import *

--- a/project1/example.qmd
+++ b/project1/example.qmd
@@ -8,19 +8,19 @@ This is an example project!! I'm learning to plot in python!
 
 Here's an example plot!
 <obs time="7/8/25 20:08" author="JF"> this is what I observe about the
-plot</obs>
+                                     plot</obs>
 <err>
     <obs time="7/8/25 20:06" author="JF"> I had some problems making the plot</obs>
     then
     I do some stuff to fix the problems
     <obs time="7/8/25 20:08" author="JF"> here are notes about the specific
-    solution</obs>
+                                         solution</obs>
 </err>
 
 ```{python}
 from pylab import *
 from pyspecdata import *
 with figlist_var() as fl:
-fl.next('this is a plot')
-fl.plot(r_[0:10])
+    fl.next('this is a plot')
+    fl.plot(r_[0:10])
 ```

--- a/tex_to_qmd.py
+++ b/tex_to_qmd.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+import re
+import sys
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def preprocess_latex(src: str) -> str:
+    """Convert custom environments and observation macros before pandoc."""
+    # replace python environment with verbatim + markers
+    src = re.sub(r"\\begin{python}.*?\n", r"\\begin{verbatim}\n%%PYTHON_START%%\n", src)
+    src = re.sub(r"\\end{python}", r"%%PYTHON_END%%\n\\end{verbatim}", src)
+
+    # convert err environment so pandoc will parse inside
+    src = src.replace("\\begin{err}", '<div class="err">')
+    src = src.replace("\\end{err}", '</div>')
+
+    # handle \o[...]{} observations
+    out = []
+    i = 0
+    while True:
+        idx = src.find('\\o[', i)
+        if idx == -1:
+            out.append(src[i:])
+            break
+        out.append(src[i:idx])
+        j = idx + 2
+        if j >= len(src) or src[j] != '[':
+            out.append(src[idx:])
+            break
+        j += 1
+        k = src.find(']', j)
+        if k == -1:
+            out.append(src[idx:])
+            break
+        attrs = src[j:k]
+        j = k + 1
+        if j >= len(src) or src[j] != '{':
+            out.append(src[idx:])
+            break
+        j += 1
+        depth = 1
+        start = j
+        while j < len(src) and depth > 0:
+            if src[j] == '{':
+                depth += 1
+            elif src[j] == '}':
+                depth -= 1
+            j += 1
+        body = src[start:j - 1]
+        m = re.match(r'(.*?)\s*(\(([^)]+)\))?$', attrs.strip())
+        time = m.group(1).strip() if m else attrs.strip()
+        author = m.group(3) if m else None
+        tag = f'<obs time="{time}"' + (f' author="{author}"' if author else '') + f'>{body}</obs>'
+        out.append(tag)
+        i = j
+    return ''.join(out)
+
+
+def clean_html_escapes(text: str) -> str:
+    return text.replace('\\<', '<').replace('\\>', '>').replace('\\"', '"')
+
+
+def finalize_markers(text: str) -> str:
+    lines = []
+    in_py = False
+    for line in text.splitlines():
+        if re.match(r'^\s*%%PYTHON_START%%', line):
+            lines.append('```{python}')
+            in_py = True
+            continue
+        if re.match(r'^\s*%%PYTHON_END%%', line):
+            lines.append('```')
+            in_py = False
+            continue
+        if in_py and line.startswith('    '):
+            lines.append(line[4:])
+        else:
+            lines.append(line)
+    content = "\n".join(lines)
+    return content.replace('<div class="err">', '<err>').replace('</div>', '</err>')
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: tex_to_qmd.py file.tex", file=sys.stderr)
+        sys.exit(1)
+
+    inp = Path(sys.argv[1])
+    if not inp.exists():
+        print(f"File not found: {inp}", file=sys.stderr)
+        sys.exit(1)
+
+    base = inp.with_suffix('')
+    src = inp.read_text()
+    pre_content = preprocess_latex(src)
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix='.tex') as pre:
+        pre.write(pre_content.encode())
+        pre_path = pre.name
+
+    mid_fd, mid_path = tempfile.mkstemp()
+    Path(mid_path).unlink()  # we just want the name; pandoc will create it
+
+    try:
+        subprocess.run(['quarto', 'pandoc', pre_path, '-f', 'latex', '-t', 'markdown', '-o', mid_path], check=True)
+    finally:
+        Path(pre_path).unlink(missing_ok=True)
+
+    mid_text = Path(mid_path).read_text()
+    Path(mid_path).unlink(missing_ok=True)
+
+    clean_text = clean_html_escapes(mid_text)
+    final_text = finalize_markers(clean_text)
+    out_path = base.with_suffix('.qmd')
+    out_path.write_text(final_text)
+    print(f"Wrote {out_path}")
+
+
+if __name__ == '__main__':
+    main()

--- a/tex_to_qmd.py
+++ b/tex_to_qmd.py
@@ -172,7 +172,7 @@ def format_tags(text: str, indent_str: str = '    ') -> str:
             lines = part.splitlines(True)
             for line in lines:
                 if line.strip():
-                    out.append(indent_str * indent + line.lstrip())
+                    out.append(indent_str * indent + line)
                 else:
                     out.append(line)
             prev_tag = None


### PR DESCRIPTION
## Summary
- implement Python implementation `tex_to_qmd.py` of old .tex format to qmd
- preserve custom environments and observation macros when converting LaTeX

## Testing
- `./tex_to_qmd.py project1/example.tex`
- `quarto render project1/example.qmd --to html --output example.html --no-execute`

------
https://chatgpt.com/codex/tasks/task_e_686db46f0ccc832bb7fda3bd53aa1cec