### PR TITLE
Handle verbatim and preserve blank lines

### DIFF
--- a/project1/example.qmd
+++ b/project1/example.qmd
@@ -1,13 +1,20 @@
 # Example project
 
-This is an example project!! I'm learning to plot in python!
+This is an example project!!
+
+```
+this is a verbatim block
+   yes, it is!!
+```
+
+I'm learning to plot in python!
 
 ## some basic examples!
 
 ### example plot {#sec:examplePlot1}
 
 Here's an example plot!
-<obs time="7/8/25 20:08" author="JF">this is what I observe about the plot</obs>
+<obs time="7/8/25 20:08" author="JF">this is what I observe about the plot there is no space before the debug block</obs>
 <err>
     <obs time="7/8/25 20:06" author="JF">I had some problems making the plot</obs>
     then I do some stuff to fix the problems
@@ -15,15 +22,19 @@ Here's an example plot!
 </err>
 
 ```{python}
-%load_ext pyspecdata.ipy
-from pyspecdata import nddata
-from numpy import r_
-x = nddata(r_[0:10],'x')
-x
+from pylab import *
+from pyspecdata import *
+with figlist_var() as fl:
+    fl.next('this is a plot')
+    fl.plot(r_[0:10])
 ```
 
-now show the square
+continue
 
-```{python}
-x**2
-```
+<err>
+    <obs time="7/9/25 11:04" author="JF">maybe I'm having issues continuing!</obs>
+    resolve those issues!
+    <obs time="7/9/25 11:04" author="JF">I did some stuff, but it was insufficient</obs>
+    continue debugging
+
+</err>

--- a/project1/example.qmd
+++ b/project1/example.qmd
@@ -21,6 +21,17 @@ Here's an example plot!
     <obs time="7/8/25 20:08" author="JF">here are notes about the specific solution</obs>
 </err>
 
+<obs time="11/27 16:51">the `alec_BRD` branch doesn't support the 1.5D regularization directly! -- this is why we need the loop</obs>
+<obs time="2/15/24 11:55">on coming back to this, note that I have 1.5D working from the $^2$H paper, just note with BRD yet</obs>
+
+<err>
+     fix (in file save script): slicing by index yells at me, maybe?
+
+    fix (in file save script): trying to convolve gives me a fine grating, like there's a problem with the enforce causality thing?
+
+    fix (in file save script): two sets of double brackets for assignment doesn't work but comma-separated version works.
+</err>
+
 ```{python}
 from pylab import *
 from pyspecdata import *

--- a/project1/example.qmd
+++ b/project1/example.qmd
@@ -21,15 +21,15 @@ Here's an example plot!
     <obs time="7/8/25 20:08" author="JF">here are notes about the specific solution</obs>
 </err>
 
-<obs time="11/27 16:51">the `alec_BRD` branch doesn't support the 1.5D regularization directly! -- this is why we need the loop</obs>
-<obs time="2/15/24 11:55">on coming back to this, note that I have 1.5D working from the $^2$H paper, just note with BRD yet</obs>
+<obs time="11/27 16:51">Make sure there is no space betwen the err and obs here!!</obs>
+<obs time="2/15/24 11:55">another observation</obs>
 
 <err>
-     fix (in file save script): slicing by index yells at me, maybe?
+     Make sure that this line lines up with the following lines.
 
-    fix (in file save script): trying to convolve gives me a fine grating, like there's a problem with the enforce causality thing?
+    Another step for debugging.
 
-    fix (in file save script): two sets of double brackets for assignment doesn't work but comma-separated version works.
+    And another step for debugging -- make sure there is no space between this and closing tag.
 </err>
 
 ```{python}

--- a/project1/example.tex
+++ b/project1/example.tex
@@ -15,15 +15,15 @@ Here's an example plot!
     then I do some stuff to fix the problems
     \o[7/8/25 20:08 (JF)]{here are notes about the specific solution}
 \end{err}
-\o[11/27 16:51]{the \texttt{alec_BRD} branch doesn't support the 1.5D regularization directly! -- this is why we need the loop}
-\o[2/15/24 11:55]{on coming back to this, note that I have 1.5D working from the $^2$H paper, just note with BRD yet}
+\o[11/27 16:51]{Make sure there is no space betwen the err and obs here!!}
+\o[2/15/24 11:55]{another observation}
 
 \begin{err}
-    fix (in file save script): slicing by index yells at me, maybe?
+    Make sure that this line lines up with the following lines.
 
-    fix (in file save script): trying to convolve gives me a fine grating, like there's a problem with the enforce causality thing?
+    Another step for debugging.
 
-    fix (in file save script): two sets of double brackets for assignment doesn't work but comma-separated version works.
+    And another step for debugging -- make sure there is no space between this and closing tag.
 \end{err}
 \par
 \begin{python}[on]

--- a/project1/example.tex
+++ b/project1/example.tex
@@ -1,10 +1,15 @@
 \section{Example project}
 This is an example project!!
+\begin{verbatim}
+this is a verbatim block
+   yes, it is!!
+\end{verbatim}
 I'm learning to plot in python!
+
 \subsection{some basic examples!}
 \subsubsection{example plot}\label{sec:examplePlot1}
 Here's an example plot!
-\o[7/8/25 20:08 (JF)]{this is what I observe about the plot}
+\o[7/8/25 20:08 (JF)]{this is what I observe about the plot there is no space before the debug block}
 \begin{err}
     \o[7/8/25 20:06 (JF)]{I had some problems making the plot}
     then I do some stuff to fix the problems
@@ -19,3 +24,12 @@ with figlist_var() as fl:
     fl.plot(r_[0:10])
 \end{python}
 \par
+continue
+
+\begin{err}
+    \o[7/9/25 11:04 (JF)]{maybe I'm having issues continuing!}
+    resolve those issues!
+    \o[7/9/25 11:04 (JF)]{I did some stuff, but it was insufficient}
+    continue debugging
+
+\end{err}

--- a/project1/example.tex
+++ b/project1/example.tex
@@ -15,6 +15,16 @@ Here's an example plot!
     then I do some stuff to fix the problems
     \o[7/8/25 20:08 (JF)]{here are notes about the specific solution}
 \end{err}
+\o[11/27 16:51]{the \texttt{alec_BRD} branch doesn't support the 1.5D regularization directly! -- this is why we need the loop}
+\o[2/15/24 11:55]{on coming back to this, note that I have 1.5D working from the $^2$H paper, just note with BRD yet}
+
+\begin{err}
+    fix (in file save script): slicing by index yells at me, maybe?
+
+    fix (in file save script): trying to convolve gives me a fine grating, like there's a problem with the enforce causality thing?
+
+    fix (in file save script): two sets of double brackets for assignment doesn't work but comma-separated version works.
+\end{err}
 \par
 \begin{python}[on]
 from pylab import *


### PR DESCRIPTION
## Summary
- support converting `verbatim` environments to fenced code blocks
- keep blank lines before `<err>` and observation tags

## Testing
- `python3 -m py_compile tex_to_qmd.py`
- `python3 tex_to_qmd.py /tmp/v2.tex`


------
https://chatgpt.com/codex/tasks/task_e_686df47c3f98832ba5fb3de3d1d6e9ec