### PR TITLE
Fix err block spacing

### DIFF
--- a/project1/example.qmd
+++ b/project1/example.qmd
@@ -20,12 +20,11 @@ Here's an example plot!
     then I do some stuff to fix the problems
     <obs time="7/8/25 20:08" author="JF">here are notes about the specific solution</obs>
 </err>
-
 <obs time="11/27 16:51">Make sure there is no space betwen the err and obs here!!</obs>
 <obs time="2/15/24 11:55">another observation</obs>
 
 <err>
-     Make sure that this line lines up with the following lines.
+    Make sure that this line lines up with the following lines.
 
     Another step for debugging.
 

--- a/tex_to_qmd.py
+++ b/tex_to_qmd.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""this script has been entirely vibe-coded based on the tex example included in the repo!"""
 import re
 import sys
 import subprocess
@@ -160,10 +161,13 @@ def format_observations(text: str) -> str:
 def format_tags(text: str, indent_str: str = '    ') -> str:
     """Format <err> blocks with indentation and tidy <obs> tags."""
     text = format_observations(text)
+    # normalize whitespace around err tags
+    text = re.sub(r'<err>[ \t]*\n+', '<err>\n', text)
+    text = re.sub(r'<err>[ \t]+', '<err>\n', text)
+    text = re.sub(r'</err>[ \t]+', '</err>', text)
     # ensure opening obs tags start on a new line without collapsing blank lines
     text = re.sub(r'(\n+)[ \t]*(<obs)', r'\1\2', text)
     text = re.sub(r'(?<!^)(?<!\n)(<obs)', r'\n\1', text)
-    text = re.sub(r'<err>[ \t]*\n+', '<err>\n', text)
     # ensure a newline after closing obs tags but keep extra blank lines
     text = re.sub(r'</obs>[ \t]+', '</obs>', text)
     text = re.sub(r'</obs>(?!\n)', '</obs>\n', text)


### PR DESCRIPTION
## Summary
- fix indentation and spacing around `<err>` blocks
- run converter on example tex
- vibe-coded comment at the top of `tex_to_qmd.py`

## Testing
- `python3 -m py_compile tex_to_qmd.py`
- `python3 tex_to_qmd.py project1/example.tex > /tmp/run_output.txt`

------
https://chatgpt.com/codex/tasks/task_e_686e88914024832bba4f8389b7d8d8cd