### PR TITLE
Update obs.lua to handle error blocks and observation spans

### DIFF
--- a/obs.lua
+++ b/obs.lua
@@ -35,21 +35,50 @@ function Inlines(inls)
         end
         if j <= #inls then
           local author, when = parse_attrs(attr)
-          if author and when then
-            local prefix = pandoc.Span(
-              { pandoc.Str(when .. ' ' .. author .. ':') },
+          local prefix_parts = {}
+          if when then table.insert(prefix_parts, when) end
+          if author then table.insert(prefix_parts, author) end
+          local prefix = nil
+          if #prefix_parts > 0 then
+            local txt = table.concat(prefix_parts, ' ') .. ':'
+            prefix = pandoc.Span(
+              { pandoc.Str(txt) },
               pandoc.Attr('', {}, { style = 'font-size:85%; color:green;' })
             )
-            local body = pandoc.Span(
-              pandoc.List(inner),
-              pandoc.Attr('', {}, { style = 'color:blue;' })
-            )
+          end
+          local body = pandoc.Span(
+            pandoc.List(inner),
+            pandoc.Attr('', {}, { style = 'color:blue;' })
+          )
+          if prefix then
             table.insert(out, prefix)
             table.insert(out, pandoc.Space())
-            table.insert(out, body)
-            i = j + 1
-            goto continue
           end
+          table.insert(out, body)
+          i = j + 1
+          goto continue
+        end
+      elseif el.text == '<obs>' then
+        -- simple <obs> with no attributes
+        local inner = {}
+        local j = i + 1
+        while j <= #inls do
+          local cur = inls[j]
+          if cur.t == 'RawInline' and cur.format == 'html' and cur.text:match('^</obs>$') then
+            break
+          else
+            table.insert(inner, cur)
+          end
+          j = j + 1
+        end
+        if j <= #inls then
+          local body = pandoc.Span(
+            pandoc.List(inner),
+            pandoc.Attr('', {}, { style = 'color:blue;' })
+          )
+          table.insert(out, body)
+          i = j + 1
+          goto continue
         end
       end
     end
@@ -60,48 +89,80 @@ function Inlines(inls)
   return out
 end
 
--- Convert <err>...</err> segments within a paragraph into a styled Div
-function Para(para)
-  local out_blocks = pandoc.List{}
-  local buf = pandoc.List{}
+-- Convert <err>...</err> blocks spanning multiple paragraphs into a styled Div
+function Blocks(blocks)
+  local out = pandoc.List{}
   local i = 1
-  local inlines = para.content
-  while i <= #inlines do
-    local el = inlines[i]
-    if el.t == 'RawInline' and el.format == 'html' and el.text == '<err>' then
-      if #buf > 0 then
-        out_blocks:insert(pandoc.Para(buf))
-        buf = pandoc.List{}
-      end
-      local inner = pandoc.List{}
-      i = i + 1
-      while i <= #inlines do
-        local cur = inlines[i]
-        if cur.t == 'RawInline' and cur.format == 'html' and cur.text == '</err>' then
+  while i <= #blocks do
+    local blk = blocks[i]
+    local handled = false
+    if blk.t == 'Para' then
+      local inlines = blk.content
+      for pos, inline in ipairs(inlines) do
+        if inline.t == 'RawInline' and inline.format == 'html' and inline.text == '<err>' then
+          local inner = pandoc.List{}
+          local closing_in_para = false
+          local rest = pandoc.List{}
+          local j = pos + 1
+          while j <= #inlines do
+            local cur = inlines[j]
+            if cur.t == 'RawInline' and cur.format == 'html' and cur.text == '</err>' then
+              closing_in_para = true
+              break
+            else
+              rest:insert(cur)
+            end
+            j = j + 1
+          end
+          if #rest > 0 then
+            inner:insert(pandoc.Para(rest))
+          end
+          if not closing_in_para then
+            i = i + 1
+            while i <= #blocks do
+              local cur = blocks[i]
+              local closing_found = false
+              if cur.t == 'Para' then
+                for cpos, cin in ipairs(cur.content) do
+                  if cin.t == 'RawInline' and cin.format == 'html' and cin.text == '</err>' then
+                    if cpos > 1 then
+                      local before = pandoc.List{}
+                      for k = 1, cpos - 1 do
+                        before:insert(cur.content[k])
+                      end
+                      if #before > 0 then
+                        inner:insert(pandoc.Para(before))
+                      end
+                    end
+                    closing_found = true
+                    break
+                  end
+                end
+              end
+              if closing_found then
+                break
+              else
+                inner:insert(cur)
+              end
+              i = i + 1
+            end
+          end
+          local header = pandoc.Para({
+            pandoc.Span({pandoc.Str('DEBUG:')}, pandoc.Attr('', {}, {style = 'color:grey;'}))
+          })
+          local body = pandoc.Div(inner, pandoc.Attr('', {}, {style = 'margin:10px; border:0px;'}))
+          local div = pandoc.Div({header, body}, pandoc.Attr('', {}, {style = 'margin:0px; border:1px solid grey; padding:0px;'}))
+          out:insert(div)
+          handled = true
           break
-        else
-          inner:insert(cur)
         end
-        i = i + 1
       end
-      local header = pandoc.Para({
-        pandoc.Span({pandoc.Str('DEBUG:')}, pandoc.Attr('', {}, {style = 'color:grey;'}))
-      })
-      local body = pandoc.Para(inner)
-      local div = pandoc.Div({header, pandoc.Div({body}, pandoc.Attr('', {}, {style = 'margin:10px; border:0px;'}))}, pandoc.Attr('', {}, {style = 'margin:0px; border:1px solid grey; padding:0px;'}))
-      out_blocks:insert(div)
-    else
-      buf:insert(el)
+    end
+    if not handled then
+      out:insert(blk)
     end
     i = i + 1
   end
-  if #out_blocks == 0 then
-    return nil
-  else
-    if #buf > 0 then
-      out_blocks:insert(pandoc.Para(buf))
-    end
-    return out_blocks
-  end
+  return out
 end
 


### PR DESCRIPTION
## Summary
- improve `<obs>` handling so spans render even without author or time
- rewrite `<err>` processing to wrap all enclosed blocks

## Testing
- `quarto pandoc project1/example.qmd --lua-filter obs.lua -t html -o /tmp/out.html`
- `quarto pandoc project1/subproject1/tasks.qmd --lua-filter obs.lua -t html -o /tmp/task.html`
- `./githooks/ctags`


------
https://chatgpt.com/codex/tasks/task_e_686e89492968832ba526384b4e15fa56