### PR TITLE
Fix err indentation

### DIFF
--- a/project1/example.qmd
+++ b/project1/example.qmd
@@ -16,20 +16,20 @@ I'm learning to plot in python!
 Here's an example plot!
 <obs time="7/8/25 20:08" author="JF">this is what I observe about the plot there is no space before the debug block</obs>
 <err>
-    <obs time="7/8/25 20:06" author="JF">I had some problems making the plot</obs>
-    then I do some stuff to fix the problems *in italics!*
-    <obs time="7/8/25 20:08" author="JF">here are notes about the specific solution</obs>
+  <obs time="7/8/25 20:06" author="JF">I had some problems making the plot</obs>
+  then I do some stuff to fix the problems *in italics!*
+  <obs time="7/8/25 20:08" author="JF">here are notes about the specific solution</obs>
 </err>
 <obs time="11/27 16:51">Make sure there is no space betwen the err and obs here!!</obs>
 <obs time="2/15/24 11:55">another observation</obs>
 ø$\checkmark$
 
 <err>
-    Make sure that this line lines up with the following lines.
+  Make sure that this line lines up with the following lines.
 
-    Another step for debugging.
+  Another step for debugging.
 
-    And another step for debugging -- make sure there is no space between this and closing tag.
+  And another step for debugging -- make sure there is no space between this and closing tag.
 </err>
 
 ```{python}
@@ -43,9 +43,9 @@ with figlist_var() as fl:
 continue
 
 <err>
-    <obs time="7/9/25 11:04" author="JF">maybe I'm having issues continuing!</obs>
-    resolve those issues!
-    <obs time="7/9/25 11:04" author="JF">I did some stuff, but it was insufficient</obs>
-    continue debugging
+  <obs time="7/9/25 11:04" author="JF">maybe I'm having issues continuing!</obs>
+  resolve those issues!
+  <obs time="7/9/25 11:04" author="JF">I did some stuff, but it was insufficient</obs>
+  continue debugging
 
 </err>

--- a/tex_to_qmd.py
+++ b/tex_to_qmd.py
@@ -164,7 +164,7 @@ def format_observations(text: str) -> str:
     return obs_re.sub(repl, text)
 
 
-def format_tags(text: str, indent_str: str = '    ') -> str:
+def format_tags(text: str, indent_str: str = '  ') -> str:
     """Format <err> blocks with indentation and tidy <obs> tags."""
     text = format_observations(text)
     # normalize whitespace around err tags


### PR DESCRIPTION
## Summary
- format <err> blocks with two-space indentation
- update example <err> sections to match new indent

## Testing
- `quarto render project1/example.qmd --no-execute`

------
https://chatgpt.com/codex/tasks/task_e_686eadd482d0832bb2a96d64f7e39526