### PR TITLE
Ensure independent python blocks when converting TeX

### DIFF
--- a/project1/example.qmd
+++ b/project1/example.qmd
@@ -22,7 +22,7 @@ Here's an example plot!
 </err>
 <obs time="11/27 16:51">Make sure there is no space betwen the err and obs here!!</obs>
 <obs time="2/15/24 11:55">another observation</obs>
-ø$\checkmark$
+<obs>$\checkmark$</obs>
 
 <err>
     Make sure that this line lines up with the following lines.
@@ -33,6 +33,13 @@ Here's an example plot!
 </err>
 
 ```{python}
+%reset -f
+from pylab import *
+plot(r_[0:10])
+```
+
+```{python}
+%reset -f
 from pylab import *
 from pyspecdata import *
 with figlist_var() as fl:


### PR DESCRIPTION
## Summary
- reset the Python session at the start of each code block when converting from TeX
- regenerate project1/example.qmd using the updated script

## Testing
- `python3 -m py_compile tex_to_qmd.py`
- `python3 tex_to_qmd.py project1/example.tex`

------
https://chatgpt.com/codex/tasks/task_e_686eae861698832baa25c967d240c562