### PR TITLE
Fix nav to ignore title headers

### DIFF
--- a/fast_build.py
+++ b/fast_build.py
@@ -363,6 +363,14 @@ def parse_headings(html_path: Path):
     tree = lxml_html.parse(str(html_path), parser)
     root = tree.getroot()
     headings = root.xpath("//h1|//h2|//h3|//h4|//h5|//h6")
+    # Skip headings used for the page title which Quarto renders with the
+    # ``title`` class. Including these in the navigation duplicates the page
+    # title entry in the section list.
+    def is_page_title(h):
+        cls = h.get('class') or ''
+        return 'title' in cls.split()
+
+    headings = [h for h in headings if not is_page_title(h)]
     items: list[dict] = []
     stack = []
     for h in headings:


### PR DESCRIPTION
## Summary
- exclude headers with the `title` class when parsing headings

## Testing
- `python3 -m py_compile fast_build.py`

------
https://chatgpt.com/codex/tasks/task_e_68740c7a8ac4832b9d29a6a6ab3429ae