### PR TITLE
Add dependency checks and extend notebook timeout

### DIFF
--- a/fast_build.py
+++ b/fast_build.py
@@ -5,6 +5,7 @@ import hashlib
 import os
 import re
 import subprocess
+import sys
 import time
 import traceback
 from pathlib import Path
@@ -17,6 +18,7 @@ import yaml
 from watchdog.observers.polling import PollingObserver as Observer
 from watchdog.events import FileSystemEventHandler
 from selenium import webdriver
+from selenium.common.exceptions import WebDriverException
 import selenium
 from jinja2 import Environment, FileSystemLoader
 import nbformat
@@ -59,6 +61,36 @@ if not shutil.which("pandoc"):
     quarto_pandoc = Path("/opt/quarto/bin/tools/x86_64/pandoc")
     if quarto_pandoc.exists():
         os.environ["PATH"] += os.pathsep + str(quarto_pandoc.parent)
+
+# Dependency checks
+if shutil.which("pandoc") is None:
+    print(
+        "Pandoc not found.\n"
+        "Install it from https://pandoc.org/installing.html\n"
+        "  • Debian/Ubuntu:  sudo apt-get install pandoc\n"
+        "  • macOS (Homebrew):  brew install pandoc"
+    )
+    sys.exit(1)
+
+options = webdriver.ChromeOptions()
+options.add_argument("--headless")
+try:
+    webdriver.Chrome(options=options).quit()
+except WebDriverException:
+    print(
+        "ChromeDriver not found or incompatible.\n"
+        "See Selenium's driver installation docs:\n"
+        "  https://www.selenium.dev/documentation/webdriver/getting_started/install_drivers/\n"
+        "Ensure the driver is on your PATH or provide its location to webdriver.Chrome().",
+    )
+    sys.exit(1)
+
+HAS_PANDOC_CROSSREF = shutil.which("pandoc-crossref") is not None
+if not HAS_PANDOC_CROSSREF:
+    print(
+        "pandoc-crossref not found. Install it for cross-references:\n"
+        "  https://github.com/lierdakil/pandoc-crossref"
+    )
 
 include_pattern = re.compile(
     r"\{\{\s*<\s*(include|embed)\s+([^>\s]+)\s*>\s*\}\}"
@@ -158,7 +190,7 @@ def execute_code_blocks(
             nb = nbformat.v4.new_notebook()
             nb.cells = [nbformat.v4.new_code_cell(c) for c in codes]
             ep = LoggingExecutePreprocessor(
-                kernel_name="python3", timeout=300, allow_errors=True
+                kernel_name="python3", timeout=10800, allow_errors=True
             )
             try:
                 ep.preprocess(
@@ -442,8 +474,6 @@ def render_file(
         "--embed-resources",
         "--lua-filter",
         os.path.relpath(BUILD_DIR / "obs.lua", dest.parent),
-        "--filter",
-        "pandoc-crossref",
         "--citeproc",
         (
             f"--mathjax={os.path.relpath(BUILD_DIR / 'mathjax' / 'es5' / 'tex-mml-chtml.js', dest.parent)}?config=TeX-AMS_CHTML"
@@ -453,9 +483,11 @@ def render_file(
         "-o",
         dest.with_suffix(".html").name,
     ]
-    if bibliography:
+    if HAS_PANDOC_CROSSREF:
+        args += ["--filter", "pandoc-crossref"]
+    if bibliography and Path(bibliography).exists():
         args += ["--bibliography", os.path.relpath(bibliography, dest.parent)]
-    if csl:
+    if csl and Path(csl).exists():
         args += ["--csl", os.path.relpath(csl, dest.parent)]
     try:
         subprocess.run(args, check=True, cwd=dest.parent, capture_output=True)


### PR DESCRIPTION
## Summary
- add startup checks for Pandoc and ChromeDriver with installation guidance
- increase notebook execution timeout to 3 hours
- skip pandoc-crossref and bibliography/CSL options when unavailable

## Testing
- `bash test/watchdog_test.sh` *(fails: ChromeDriver not found)*


------
https://chatgpt.com/codex/tasks/task_e_6893f86f87e4832ba87d7257eb179708