### PR TITLE
Add YAML graph watcher and tests

### DIFF
--- a/graph/graph.dot
+++ b/graph/graph.dot
@@ -1,0 +1,7 @@
+digraph G {
+    "A" [label="Start"];
+    "B" [label="Middle"];
+    "C" [label="End"];
+    "A" -> "B";
+    "B" -> "C";
+}

--- a/graph/graph.yaml
+++ b/graph/graph.yaml
@@ -1,0 +1,12 @@
+A:
+  text: "Start"
+  children: [B]
+  parents: []
+B:
+  text: "Middle"
+  parents: [A]
+  children: [C]
+C:
+  text: "End"
+  parents: [B]
+  children: []

--- a/test/test_graph_conversion.py
+++ b/test/test_graph_conversion.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import yaml_graph
+
+
+def test_yaml_to_dot_matches_existing():
+    root = Path(__file__).resolve().parents[1]
+    yaml_path = root / "graph" / "graph.yaml"
+    dot_expected = (root / "graph" / "graph.dot").read_text().strip()
+    graph = yaml_graph.load_yaml(yaml_path)
+    dot_generated = yaml_graph.to_dot(graph).strip()
+    assert dot_generated == dot_expected

--- a/test/test_svg_valid.py
+++ b/test/test_svg_valid.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+import subprocess
+import xml.etree.ElementTree as ET
+import sys
+import shutil
+import urllib.request
+import zipfile
+
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.chrome.service import Service
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import yaml_graph
+
+
+def test_generated_svg_is_valid(tmp_path):
+    root = Path(__file__).resolve().parents[1]
+    yaml_path = root / "graph" / "graph.yaml"
+    dot_path = tmp_path / "graph.dot"
+    svg_path = tmp_path / "graph.svg"
+
+    yaml_graph.write_dot_from_yaml(yaml_path, dot_path)
+    subprocess.run([
+        "dot", "-Tsvg", str(dot_path), "-o", str(svg_path)
+    ], check=True)
+
+    options = Options()
+    options.add_argument("--headless")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+
+    chrome_version = subprocess.check_output(["google-chrome", "--version"]).decode().split()[2]
+    url = f"https://storage.googleapis.com/chrome-for-testing-public/{chrome_version}/linux64/chromedriver-linux64.zip"
+    zip_path = tmp_path / "chromedriver.zip"
+    urllib.request.urlretrieve(url, zip_path)
+    with zipfile.ZipFile(zip_path) as zf:
+        zf.extractall(tmp_path)
+    driver_path = tmp_path / "chromedriver-linux64" / "chromedriver"
+    driver_path.chmod(0o755)
+    service = Service(str(driver_path))
+    driver = webdriver.Chrome(service=service, options=options)
+    try:
+        driver.get(f"file://{svg_path}")
+        assert "<svg" in driver.page_source
+    finally:
+        driver.quit()
+
+    root_tag = ET.parse(svg_path).getroot().tag
+    assert "svg" in root_tag

--- a/watch_graph.py
+++ b/watch_graph.py
@@ -1,0 +1,84 @@
+"""Watch a YAML graph file and regenerate DOT and SVG outputs.
+
+This script uses watchdog to monitor a YAML file. When the file changes,
+a DOT file and corresponding SVG are regenerated. A headless Chrome
+instance (via Selenium) is used to display the SVG and refresh it when
+changes occur.
+"""
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+import os
+import shutil
+
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.chrome.service import Service
+
+import yaml_graph
+
+
+class GraphHandler(FileSystemEventHandler):
+    def __init__(self, yaml_file: Path, dot_file: Path, svg_file: Path, driver: webdriver.Chrome):
+        self.yaml_file = yaml_file
+        self.dot_file = dot_file
+        self.svg_file = svg_file
+        self.driver = driver
+        self.graph = {}
+        self.build()
+
+    def build(self) -> None:
+        """Rebuild the DOT and SVG files and load them in the browser."""
+        self.graph = yaml_graph.load_yaml(self.yaml_file)
+        self.dot_file.write_text(yaml_graph.to_dot(self.graph))
+        subprocess.run([
+            "dot",
+            "-Tsvg",
+            str(self.dot_file),
+            "-o",
+            str(self.svg_file),
+        ], check=True)
+        self.driver.get(f"file://{self.svg_file}")
+
+    def on_modified(self, event):
+        if Path(event.src_path) == self.yaml_file:
+            self.build()
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Watch YAML graph and render SVG")
+    parser.add_argument("yaml_file", type=Path)
+    parser.add_argument("dot_file", type=Path)
+    parser.add_argument("svg_file", type=Path)
+    args = parser.parse_args()
+
+    options = Options()
+    options.add_argument("--headless")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+    chromedriver_path = os.environ.get("CHROMEDRIVER_PATH") or shutil.which("chromedriver")
+    service = Service(chromedriver_path) if chromedriver_path else None
+    driver = webdriver.Chrome(service=service, options=options)
+
+    handler = GraphHandler(args.yaml_file, args.dot_file, args.svg_file, driver)
+    observer = Observer()
+    observer.schedule(handler, str(args.yaml_file.parent), recursive=False)
+    observer.start()
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        observer.stop()
+    observer.join()
+    driver.quit()
+
+
+if __name__ == "__main__":
+    main()

--- a/yaml_graph.py
+++ b/yaml_graph.py
@@ -1,0 +1,102 @@
+"""Utilities for working with graphs stored in YAML.
+
+Each node is represented as a mapping with the following keys:
+- text: label for the node
+- parents: list of parent node names
+- children: list of child node names
+- subgraph: optional name of a subgraph/cluster
+
+The module loads the YAML file into an in-memory dictionary and ensures
+that parent/child relationships are symmetric. It can also emit a Graphviz
+DOT representation of the graph.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Set, Optional
+import yaml
+from collections import defaultdict
+
+
+@dataclass
+class Node:
+    text: str
+    parents: Set[str] = field(default_factory=set)
+    children: Set[str] = field(default_factory=set)
+    subgraph: Optional[str] = None
+
+
+def load_yaml(path: Path) -> Dict[str, Node]:
+    """Load a YAML graph description into a dictionary of Nodes.
+
+    Parent/child relationships are kept in sync so that if a node lists a
+    child, that child will list the node as a parent (and vice versa).
+    """
+    data = yaml.safe_load(Path(path).read_text()) or {}
+    graph: Dict[str, Node] = {}
+    for name, info in data.items():
+        graph[name] = Node(
+            text=info.get("text", name),
+            parents=set(info.get("parents", [])),
+            children=set(info.get("children", [])),
+            subgraph=info.get("subgraph"),
+        )
+    # ensure symmetry
+    for name, node in list(graph.items()):
+        for child in list(node.children):
+            if child not in graph:
+                graph[child] = Node(text=child)
+            graph[child].parents.add(name)
+        for parent in list(node.parents):
+            if parent not in graph:
+                graph[parent] = Node(text=parent)
+            graph[parent].children.add(name)
+    return graph
+
+
+def to_dot(graph: Dict[str, Node]) -> str:
+    """Create a DOT representation of the graph."""
+    lines = ["digraph G {"]
+    # organise nodes by subgraph
+    subgraphs: Dict[Optional[str], list[str]] = defaultdict(list)
+    for name, node in graph.items():
+        subgraphs[node.subgraph].append(name)
+    # render subgraphs
+    for subgraph, nodes in subgraphs.items():
+        if subgraph is None:
+            continue
+        lines.append(f'    subgraph cluster_{subgraph} {{')
+        lines.append(f'        label="{subgraph}";')
+        for name in nodes:
+            lines.append(f'        "{name}" [label="{graph[name].text}"];')
+        lines.append("    }")
+    # nodes not in a subgraph
+    for name in subgraphs[None]:
+        lines.append(f'    "{name}" [label="{graph[name].text}"];')
+    # edges
+    for name, node in graph.items():
+        for child in node.children:
+            lines.append(f'    "{name}" -> "{child}";')
+    lines.append("}")
+    return "\n".join(lines) + "\n"
+
+
+def write_dot_from_yaml(yaml_path: Path, dot_path: Path) -> None:
+    """Read YAML file and write a DOT file."""
+    graph = load_yaml(yaml_path)
+    dot_path.write_text(to_dot(graph))
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Convert YAML graph to DOT")
+    parser.add_argument("yaml_file", type=Path)
+    parser.add_argument("dot_file", type=Path)
+    args = parser.parse_args()
+    write_dot_from_yaml(args.yaml_file, args.dot_file)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- represent graph connections in a YAML file and convert to DOT
- watch the YAML for changes to rebuild DOT/SVG and refresh a headless Chrome view
- verify conversion and SVG rendering with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a251bae81c832baf46ed4a1f11b99c