### PR TITLE
refactor include analysis

### DIFF
--- a/fast_build.py
+++ b/fast_build.py
@@ -262,7 +262,7 @@ def analyze_includes(render_files):
     visited = set()
 
     stack = [Path(f).resolve() for f in render_files]
-    root = Path(".").resolve()
+    root = PROJECT_ROOT
     root_dirs = {Path(f).resolve(): Path(f).parent.resolve() for f in render_files}
 
     while stack:
@@ -299,11 +299,15 @@ def analyze_includes(render_files):
             key = current.as_posix()
         tree[key] = includes
 
-    roots_str = {
-        p.relative_to(root).as_posix(): d
-        for p, d in root_dirs.items()
-        if p.exists()
-    }
+    roots_str: dict[str, Path] = {}
+    for p, d in root_dirs.items():
+        if not p.exists():
+            continue
+        try:
+            rel = p.relative_to(root).as_posix()
+        except ValueError:
+            rel = p.as_posix()
+        roots_str[rel] = d
 
     return tree, roots_str, included_by
 

--- a/fast_build.py
+++ b/fast_build.py
@@ -280,7 +280,9 @@ def analyze_includes(render_files):
             if not target.exists():
                 target = (root_dir.parent / inc).resolve()
             if not target.exists():
-                continue
+                raise FileNotFoundError(
+                    f"Include file '{inc}' not found for '{current}'"
+                )
             try:
                 rel = target.relative_to(root).as_posix()
             except ValueError:
@@ -310,11 +312,6 @@ def analyze_includes(render_files):
         roots_str[rel] = d
 
     return tree, roots_str, included_by
-
-
-def build_include_map(render_files):
-    _, _, included_by = analyze_includes(render_files)
-    return included_by
 
 
 def resolve_render_file(file, included_by, render_files):
@@ -395,11 +392,6 @@ def ensure_mathjax():
     (MATHJAX_DIR / "es5").mkdir(parents=True, exist_ok=True)
     shutil.copytree(src, MATHJAX_DIR / "es5", dirs_exist_ok=True)
     shutil.rmtree(tmp)
-
-
-def build_include_tree(render_files):
-    tree, roots, _ = analyze_includes(render_files)
-    return tree, roots
 
 
 def all_files(render_files, tree):

--- a/test/test_fast_build.py
+++ b/test/test_fast_build.py
@@ -4,6 +4,7 @@ import types
 import shutil
 import os
 from pathlib import Path
+import pytest
 
 
 def import_fast_build():
@@ -46,10 +47,10 @@ def import_fast_build():
     return fast_build
 
 
-def test_build_include_map():
+def test_analyze_includes_map():
     fb = import_fast_build()
     render_files = fb.load_rendered_files()
-    include_map = fb.build_include_map(render_files)
+    _, _, include_map = fb.analyze_includes(render_files)
     assert include_map['project1/index.qmd'] == ['projects.qmd']
     assert include_map['project1/subproject1/index.qmd'] == ['project1/index.qmd']
     assert include_map['project1/subproject1/tasks.qmd'] == ['project1/subproject1/index.qmd']
@@ -74,6 +75,14 @@ def test_root_file_same_dir_include():
         root_file.unlink()
         inc_file.unlink()
         nested.rmdir()
+
+
+def test_missing_include_error(tmp_path):
+    fb = import_fast_build()
+    src = tmp_path / 'root.qmd'
+    src.write_text('{{< include missing.qmd >}}')
+    with pytest.raises(FileNotFoundError):
+        fb.analyze_includes([src.as_posix()])
 
 
 def test_build_all_includes(tmp_path):

--- a/test/test_fast_build.py
+++ b/test/test_fast_build.py
@@ -56,6 +56,26 @@ def test_build_include_map():
     assert include_map['project1/subproject1/tryforerror.qmd'] == ['project1/subproject1/index.qmd']
 
 
+def test_root_file_same_dir_include():
+    fb = import_fast_build()
+    nested = Path('project1/tmp_root')
+    nested.mkdir(parents=True, exist_ok=True)
+    root_file = nested / 'root.qmd'
+    inc_file = nested / 'inc.qmd'
+    root_file.write_text('{{< include inc.qmd >}}')
+    inc_file.write_text('content')
+    try:
+        tree, _, included_by = fb.analyze_includes([root_file.as_posix()])
+        rel_root = root_file.as_posix()
+        rel_inc = inc_file.as_posix()
+        assert tree[rel_root] == [rel_inc]
+        assert included_by[rel_inc] == [rel_root]
+    finally:
+        root_file.unlink()
+        inc_file.unlink()
+        nested.rmdir()
+
+
 def test_build_all_includes(tmp_path):
     fb = import_fast_build()
     shutil.rmtree('_build', ignore_errors=True)


### PR DESCRIPTION
## Summary
- add regression tests for include mapping and build output
- analyze include structure in one pass
- use unified include map in build and watch commands
- add optional --webtex flag to use Pandoc's webtex instead of local MathJax

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa58f67a5c832bb9119b4c2d262940