### PR TITLE
Rework incremental staging pipeline

### DIFF
--- a/fast_build.py
+++ b/fast_build.py
@@ -528,7 +528,7 @@ def render_file(
     math_arg = (
         "--webtex"
         if webtex
-        else f"--mathjax={os.path.relpath(BUILD_DIR / 'mathjax' / 'es5' / 'tex-mml-chtml.js', dest.parent)}?config=TeX-AMS_CHTML"
+        else f"--mathjax={os.path.relpath(DISPLAY_DIR / 'mathjax' / 'es5' / 'tex-mml-chtml.js', dest.parent)}?config=TeX-AMS_CHTML"
     )
     args = [
         "pandoc",
@@ -776,10 +776,8 @@ def build_all(webtex: bool = False, changed_paths=None):
     DISPLAY_DIR.mkdir(parents=True, exist_ok=True)
     if not webtex:
         ensure_mathjax()
-        # keep MathJax in the staging area for Pandoc while also mirroring it
-        # into the display tree so browsers load assets directly from the
-        # served directory instead of falling back to _build.
-        shutil.copytree(MATHJAX_DIR, BUILD_DIR / "mathjax", dirs_exist_ok=True)
+        # copy MathJax into the display tree so browsers load assets from the
+        # served directory while the staging area remains limited to fragments.
         shutil.copytree(MATHJAX_DIR, DISPLAY_DIR / "mathjax", dirs_exist_ok=True)
     # copy project configuration without the render list so individual renders
     # don't attempt to build the entire project


### PR DESCRIPTION
## Summary
- keep the staging `_build` outputs free of include substitutions and assemble served pages in a separate `_display` tree
- rebuild only the touched QMD files, execute their notebooks, and reassemble affected top-level pages while refreshing navigation in place
- update the watch server to observe the project root recursively and serve `_display` with `_build` as a fallback for shared assets

## Testing
- python -m compileall fast_build.py

------
https://chatgpt.com/codex/tasks/task_e_68f112a25588832ba18311de4fd46231